### PR TITLE
20 convert edge type into a tuple struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Graph Data Structure Library"
 repository = "https://github.com/juliuskoskela/gdsl"
 
 keywords = ["data-structure", "graph", "algorithms", "containers", "graph-theory"]
-categories = ["Data structures"]
+categories = ["data-structure"]
 
 [dependencies]
 min-max-heap = "1.3.0"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ assert!(*n1 == 42);
 assert!(n2.key() == &'B');
 
 // Get the next edge from the outbound iterator.
-let (u, v, e) = n1.iter_out().next().unwrap();
+let Edge(u, v, e) = n1.iter_out().next().unwrap();
 
 assert!(u.key() == &'A');
 assert!(v == n2);
@@ -70,12 +70,12 @@ inbound edges in case of a directed graph or adjacent edges in the case of an un
 graph.
 
 ```rust
-for (u, v, e) in &node {
+for Edge(u, v, e) in &node {
     println!("{} -> {} : {}", u.key(), v.key(), e);
 }
 
 // Transposed iteration i.e. iterating the inbound edges of a node in digrap.
-for (u, v, e) in node.iter_in() {
+for Edge(v, u, e) in node.iter_in() {
     println!("{} <- {} : {}", u.key(), v.key(), e);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -70,8 +70,15 @@ inbound edges in case of a directed graph or adjacent edges in the case of an un
 graph.
 
 ```rust
+
+// Edge is a tuple struct so can be decomposed using tuple syntax..
 for Edge(u, v, e) in &node {
     println!("{} -> {} : {}", u.key(), v.key(), e);
+}
+
+// ..or used more conventionally as one type.
+for edge in &node {
+    println!("{} -> {} : {}", edge.source().key(), edge.target().key(), edge.value());
 }
 
 // Transposed iteration i.e. iterating the inbound edges of a node in digrap.
@@ -247,7 +254,7 @@ g['A'].set(0);
 //
 // The search-object evaluates lazily. This means that the search is only
 // executed when calling either `search()` or `search_path()`.
-g['A'].pfs().map(&|u, v, e| {
+g['A'].pfs().map(&|Edge(u, v, e)| {
 
     // Since we are using a `Cell` to store the distance we use `get()` to
     // read the distance values.

--- a/examples/dijkstra.rs
+++ b/examples/dijkstra.rs
@@ -6,6 +6,7 @@
 // https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
 
 use gdsl::*;
+use gdsl::digraph::*;
 use std::cell::Cell;
 
 fn main() {
@@ -52,8 +53,7 @@ fn main() {
 	//
 	// The search-object evaluates lazily. This means that the search is only
 	// executed when calling either `search()` or `search_path()`.
-	g['A'].pfs().map(&|u, v, e| {
-
+	g['A'].pfs().map(&|Edge(u, v, e)| {
 		// Since we are using a `Cell` to store the distance we use `get()` to
 		// read the distance values.
 		let (u_dist, v_dist) = (u.get(), v.get());

--- a/examples/edmonds-karp.rs
+++ b/examples/edmonds-karp.rs
@@ -70,7 +70,7 @@ fn max_flow(g: &G) -> u64 {
 		.dfs()
 		.target(&5)
 		// 2. We exclude saturated edges from the search.
-		.filter(&|_, _, e| e.cur() < e.max())
+		.filter(&|Edge(_, _, e)| e.cur() < e.max())
 		.search_path()
 	{
 		let mut aug_flow = std::u64::MAX;

--- a/examples/edmonds-karp.rs
+++ b/examples/edmonds-karp.rs
@@ -76,14 +76,14 @@ fn max_flow(g: &G) -> u64 {
 		let mut aug_flow = std::u64::MAX;
 
 		// 3. We find the minimum augmenting flow along the path.
-		for (_, _, flow) in path.iter_edges() {
+		for Edge(_, _, flow) in path.iter_edges() {
 			if flow.max() - flow.cur() < aug_flow {
 				aug_flow = flow.max() - flow.cur();
 			}
 		}
 
 		// 4. We update the flow along the path.
-		for (_, _, flow) in path.iter_edges() {
+		for Edge(_, _, flow) in path.iter_edges() {
 			flow.update(aug_flow);
 		}
 

--- a/examples/kojarasu.rs
+++ b/examples/kojarasu.rs
@@ -94,7 +94,7 @@ fn ex1() {
 	];
 
 	let mut g = g.to_vec();
-	g.sort();
+	g.sort_by(|a, b| a.key().cmp(&b.key()));
 	let mut components = kojarasu(&g);
 
 	for (i, component) in components.iter_mut().enumerate() {
@@ -135,7 +135,7 @@ fn ex2() {
 	];
 
 	let mut g = g.to_vec();
-	g.sort();
+	g.sort_by(|a, b| a.key().cmp(&b.key()));
 	let mut components = kojarasu(&g);
 
 	for (i, component) in components.iter_mut().enumerate() {
@@ -174,7 +174,7 @@ fn ex3() {
 	];
 
 	let mut g = g.to_vec();
-	g.sort();
+	g.sort_by(|a, b| a.key().cmp(&b.key()));
 	let mut components = kojarasu(&g);
 
 	for (i, component) in components.iter_mut().enumerate() {
@@ -213,7 +213,7 @@ fn ex4() {
 	];
 
 	let mut g = g.to_vec();
-	g.sort();
+	g.sort_by(|a, b| a.key().cmp(&b.key()));
 	let mut components = kojarasu(&g);
 
 	for (i, component) in components.iter_mut().enumerate() {

--- a/examples/kojarasu.rs
+++ b/examples/kojarasu.rs
@@ -23,7 +23,7 @@ fn ordering(graph: &G) -> G {
 		if !visited.contains(next.key()) {
 			let partition = next
 				.postorder()
-				.filter(&|_, v, _| !visited.contains(v.key()))
+				.filter(&|Edge(_, v, _)| !visited.contains(v.key()))
 				.search_nodes();
 			for node in &partition {
 				visited.insert(node.key().clone());
@@ -44,7 +44,7 @@ fn kojarasu(graph: &G) -> Vec<G> {
 			let cycle = node
 				.dfs()
 				.transpose()
-				.filter(&|_, v, _| !invariant.contains(v.key()))
+				.filter(&|Edge(_, v, _)| !invariant.contains(v.key()))
 				.search_cycle();
 			match cycle {
 				Some(cycle) => {

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -34,7 +34,7 @@ fn main() {
 
 	for (a, b) in graph_cbor_vec.iter().zip(graph_json_vec.iter()) {
 		assert!(a == b);
-		for ((u, v, e), (uu, vv, ee)) in a.iter_out().zip(b.iter_out()) {
+		for (Edge(u, v, e), Edge(uu, vv, ee)) in a.iter_out().zip(b.iter_out()) {
 			assert!(u == uu);
 			assert!(v == vv);
 			assert!(e == ee);

--- a/src/digraph/graph_serde.rs
+++ b/src/digraph/graph_serde.rs
@@ -17,11 +17,10 @@ where
 	for (_, n) in g.iter() {
 		nodes.push((n.key().clone(), n.value().clone()));
 
-		for (u, v, e) in n.iter_out() {
+		for Edge(u, v, e) in n {
 			edges.push((u.key().clone(), v.key().clone(), e));
 		}
 	}
-
 	(nodes, edges)
 }
 

--- a/src/digraph/mod.rs
+++ b/src/digraph/mod.rs
@@ -5,8 +5,8 @@
 //!
 //! - `Graph` is a container type for a directed graph.
 //! - `Node` is a node type for a directed graph.
-//! - An edge is denoted by a tuple `(u, v, e)` where `u` and `v` are the
-//!  source and target node and `e` is the edge parameter.
+//! - An edge is denoted by a tuple struct `Edge(u, v, e)` where`u` and `v` are
+//! the source and target node and `e` is the edge parameter.
 //!
 //! # Example
 //!
@@ -320,7 +320,7 @@ where
     /// g.insert(Node::new("B", 0));
     /// g.insert(Node::new("C", 0));
     ///
-    /// for (key, _)in g.iter() {
+    /// for (key, _) in g.iter() {
     ///    println!("{}", key);
     /// }
     /// ```
@@ -383,7 +383,7 @@ where
                 let cycle = node
                     .dfs()
                     .transpose()
-                    .filter(&|_, v, _| !invariant.contains(v.key()))
+                    .filter(&|Edge(_, v, _)| !invariant.contains(v.key()))
                     .search_cycle();
                 match cycle {
                     Some(cycle) => {
@@ -412,7 +412,7 @@ where
             if !visited.contains(next.key()) {
                 let partition = next
                     .postorder()
-                    .filter(&|_, v, _| !visited.contains(v.key()))
+                    .filter(&|Edge(_, v, _)| !visited.contains(v.key()))
                     .search_nodes();
                 for node in &partition {
                     visited.insert(node.key().clone());
@@ -428,7 +428,7 @@ where
         s.push_str("digraph {\n");
         for (u_key, node) in self.iter() {
             s.push_str(&format!("    {}", u_key.clone()));
-            for (_, v, _) in node {
+            for Edge(_, v, _) in node {
                 s.push_str(&format!("\n    {} -> {}", u_key, v.key()));
             }
             s.push_str("\n");
@@ -466,9 +466,9 @@ where
             s.push_str("\n");
         }
         for (_, node) in self.iter() {
-            for (u, v, edge) in node {
+            for Edge(u, v, e) in node {
                 s.push_str(&format!("\t{} -> {}", u.key(), v.key()));
-                if let Some(eattrs) = eattr(&u, &v, &edge) {
+                if let Some(eattrs) = eattr(&u, &v, &e) {
                     s.push_str(&format!(" {}", Self::fmt_attr(eattrs)));
                 }
                 s.push_str("\n");

--- a/src/digraph/node/adjacent.rs
+++ b/src/digraph/node/adjacent.rs
@@ -23,33 +23,33 @@ where
         })
     }
 
-    pub fn get_outbound(&self, idx: usize) -> Option<(Node<K, N, E>, E)> {
+    pub fn get_outbound(&self, idx: usize) -> Option<(&Node<K, N, E>, &E)> {
         match self.outbound.get(idx) {
-            Some(edge) => Some((edge.0.clone(), edge.1.clone())),
+            Some(edge) => Some((&edge.0, &edge.1)),
             None => None,
         }
     }
 
-    pub fn get_inbound(&self, idx: usize) -> Option<(Node<K, N, E>, E)> {
+    pub fn get_inbound(&self, idx: usize) -> Option<(&Node<K, N, E>, &E)> {
         match self.inbound.get(idx) {
-            Some(edge) => Some((edge.0.clone(), edge.1.clone())),
+            Some(edge) => Some((&edge.0, &edge.1)),
             None => None,
         }
     }
 
-    pub fn find_outbound(&self, node: &K) -> Option<(Node<K, N, E>, E)> {
+    pub fn find_outbound(&self, node: &K) -> Option<(&Node<K, N, E>, &E)> {
         for edge in self.outbound.iter() {
             if edge.0.key() == node {
-                return Some((edge.0.clone(), edge.1.clone()));
+                return Some((&edge.0, &edge.1));
             }
         }
         None
     }
 
-    pub fn find_inbound(&self, node: &K) -> Option<(Node<K, N, E>, E)> {
+    pub fn find_inbound(&self, node: &K) -> Option<(&Node<K, N, E>, &E)> {
         for edge in self.inbound.iter() {
             if edge.0.key() == node {
-                return Some((edge.0.clone(), edge.1.clone()));
+                return Some((&edge.0, &edge.1));
             }
         }
         None

--- a/src/digraph/node/bfs.rs
+++ b/src/digraph/node/bfs.rs
@@ -124,11 +124,12 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter_out() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -147,11 +148,13 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_front() {
-			for (v, u, e) in node.iter_in() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_in() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -169,8 +172,9 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter_out() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
 						if self.target.is_some() && self.target.unwrap() == v.key() {
@@ -190,8 +194,10 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		while let Some(node) = queue.pop_front() {
-			for (v, u, e) in node.iter_in() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_in() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
 						if self.target.is_some() && self.target.unwrap() == v.key() {

--- a/src/digraph/node/dfs.rs
+++ b/src/digraph/node/dfs.rs
@@ -123,10 +123,11 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if visited.contains(v.key()) == false {
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -148,10 +149,12 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_in() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if visited.contains(v.key()) == false {
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -172,8 +175,9 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if visited.contains(v.key()) == false {
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return Some(v);
@@ -196,8 +200,10 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_in() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if visited.contains(v.key()) == false {
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return Some(v);

--- a/src/digraph/node/method.rs
+++ b/src/digraph/node/method.rs
@@ -1,8 +1,8 @@
 use super::*;
 
-pub type FilterMap<'a, K, N, E> = &'a dyn Fn(&Node<K, N, E>, &Node<K, N, E>, &E) -> bool;
-pub type Filter<'a, K, N, E> = &'a dyn Fn(&Node<K, N, E>, &Node<K, N, E>, &E) -> bool;
-pub type Map<'a, K, N, E> = &'a dyn Fn(&Node<K, N, E>, &Node<K, N, E>, &E);
+pub type FilterMap<'a, K, N, E> = &'a dyn Fn(&Edge<K, N, E>) -> bool;
+pub type Filter<'a, K, N, E> = &'a dyn Fn(&Edge<K, N, E>) -> bool;
+pub type Map<'a, K, N, E> = &'a dyn Fn(&Edge<K, N, E>);
 
 #[derive(Clone)]
 pub enum Method<'a, K, N, E>
@@ -23,12 +23,12 @@ where
 	N: Clone,
 	E: Clone,
 {
-	pub fn exec(&self, u: &Node<K, N, E>, v: &Node<K, N, E>, e: &E) -> bool {
+	pub fn exec(&self, e: &Edge<K, N, E>) -> bool {
 		match self {
 			Method::NullMethod => true,
-			Method::Map(f) => {f(u, v, e); true},
-			Method::Filter(f) => f(u, v, e),
-			Method::FilterMap(f) => f(u, v, e),
+			Method::Map(f) => {f(e); true},
+			Method::Filter(f) => f(e),
+			Method::FilterMap(f) => f(e),
 		}
 	}
 }

--- a/src/digraph/node/mod.rs
+++ b/src/digraph/node/mod.rs
@@ -45,11 +45,14 @@ use std::{cell::RefCell, fmt::Display, hash::Hash, ops::Deref, rc::Rc};
 /// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
 #[derive(Clone, PartialEq)]
-pub struct Edge<K: Clone + Hash + PartialEq + Eq + Display, N: Clone, E: Clone>(
+pub struct Edge<K, N, E>(
     pub Node<K, N, E>,
     pub Node<K, N, E>,
     pub E,
-);
+) where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone;
 
 impl<K, N, E> Edge<K, N, E>
 where

--- a/src/digraph/node/mod.rs
+++ b/src/digraph/node/mod.rs
@@ -756,37 +756,6 @@ where
     }
 }
 
-/// An iterator over the node's outbound edges.
-// pub struct RefIterOut<'a, K, N, E>
-// where
-//     K: Clone + Hash + Display + PartialEq + Eq,
-//     N: Clone,
-//     E: Clone,
-// {
-//     node: &'a Node<K, N, E>,
-//     position: usize,
-// }
-
-// impl<'a, K, N, E> Iterator for RefIterOut<'a, K, N, E>
-// where
-//     K: Clone + Hash + Display + PartialEq + Eq,
-//     N: Clone,
-//     E: Clone,
-// {
-//     type Item = EdgeRef<'a, K, N, E>;
-
-//     fn next(&mut self) -> Option<Self::Item> {
-//         match self.node.inner.2.borrow().get_outbound(self.position) {
-//             Some(current) => {
-//                 self.position += 1;
-//                 Some(EdgeRef(self.node, current.0, current.1))
-//             }
-//             None => None,
-//         }
-//     }
-// }
-
-
 pub struct IterOut<'a, K, N, E>
 where
     K: Clone + Hash + Display + PartialEq + Eq,
@@ -815,36 +784,6 @@ where
         }
     }
 }
-
-// /// An iterator over the node's inbound edges.
-// pub struct RefIterIn<'a, K, N, E>
-// where
-//     K: Clone + Hash + Display + PartialEq + Eq + Display,
-//     N: Clone,
-//     E: Clone,
-// {
-//     node: &'a Node<K, N, E>,
-//     position: usize,
-// }
-
-// impl<'a, K, N, E> Iterator for RefIterIn<'a, K, N, E>
-// where
-//     K: Clone + Hash + Display + PartialEq + Eq + Display,
-//     N: Clone,
-//     E: Clone,
-// {
-//     type Item = EdgeRef<'a, K, N, E>;
-
-//     fn next(&mut self) -> Option<Self::Item> {
-//         match self.node.inner.2.borrow().get_inbound(self.position) {
-//             Some(current) => {
-//                 self.position += 1;
-//                 Some(EdgeRef(current.0, self.node, current.1))
-//             }
-//             None => None,
-//         }
-//     }
-// }
 
 pub struct IterIn<'a, K, N, E>
 where

--- a/src/digraph/node/mod.rs
+++ b/src/digraph/node/mod.rs
@@ -31,20 +31,52 @@
 //!
 //! This node uses `Rc` for reference counting, thus it is not thread-safe.
 
+mod adjacent;
 mod bfs;
 mod dfs;
 mod method;
 mod order;
 mod path;
 mod pfs;
-mod adjacent;
 
+use self::{adjacent::*, bfs::*, dfs::*, order::*, pfs::*};
 use std::{cell::RefCell, fmt::Display, hash::Hash, ops::Deref, rc::Rc};
-use self::{bfs::*, dfs::*, order::*, pfs::*, adjacent::*};
 
-/// An edge between nodes is a tuple `(u, v, e)` where `u` is the
+/// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
-pub type Edge<K, N, E> = (Node<K, N, E>, Node<K, N, E>, E);
+#[derive(Clone, PartialEq)]
+pub struct Edge<K: Clone + Hash + PartialEq + Eq + Display, N: Clone, E: Clone>(
+    pub Node<K, N, E>,
+    pub Node<K, N, E>,
+    pub E,
+);
+
+impl<K, N, E> Edge<K, N, E>
+where
+    K: Clone + Hash + PartialEq + Eq + Display,
+    N: Clone,
+    E: Clone,
+{
+    /// Returns the source node of the edge.
+    pub fn source(&self) -> &Node<K, N, E> {
+        &self.0
+    }
+
+    /// Returns the target node of the edge.
+    pub fn target(&self) -> &Node<K, N, E> {
+        &self.1
+    }
+
+    /// Returns the edge's value.
+    pub fn value(&self) -> &E {
+        &self.2
+    }
+
+    /// Reverse the edge's direction.
+    pub fn reverse(&self) -> Edge<K, N, E> {
+        Edge(self.1.clone(), self.0.clone(), self.2.clone())
+    }
+}
 
 /// A `Node<K, N, E>` is a key value pair smart-pointer, which includes inbound
 /// and outbound connections to other nodes. Nodes can be created individually
@@ -66,7 +98,7 @@ pub type Edge<K, N, E> = (Node<K, N, E>, Node<K, N, E>, E);
 /// b.connect(&c, 0.09);
 /// c.connect(&b, 12.9);
 ///
-/// let (u, v, e) = a.iter_out().next().unwrap();
+/// let Edge(u, v, e) = a.iter_out().next().unwrap();
 ///
 /// assert!(u == a);
 /// assert!(v == b);
@@ -139,46 +171,46 @@ where
         &self.inner.1
     }
 
-	/// Returns the out-degree of the node. The out degree is the number of
-	/// outbound edges.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let a = Node::new(0x1, "A");
-	/// let b = Node::new(0x2, "B");
-	/// let c = Node::new(0x4, "C");
-	///
-	/// a.connect(&b, 0.42);
-	/// a.connect(&c, 1.7);
-	///
-	/// assert!(a.out_degree() == 2);
-	/// ```
-	pub fn out_degree(&self) -> usize {
-		self.inner.2.borrow().len_outbound()
-	}
+    /// Returns the out-degree of the node. The out degree is the number of
+    /// outbound edges.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let a = Node::new(0x1, "A");
+    /// let b = Node::new(0x2, "B");
+    /// let c = Node::new(0x4, "C");
+    ///
+    /// a.connect(&b, 0.42);
+    /// a.connect(&c, 1.7);
+    ///
+    /// assert!(a.out_degree() == 2);
+    /// ```
+    pub fn out_degree(&self) -> usize {
+        self.inner.2.borrow().len_outbound()
+    }
 
-	/// Returns the in-degree of the node. The out degree is the number of
-	/// inbound edges.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let a = Node::new(0x1, "A");
-	/// let b = Node::new(0x2, "B");
-	/// let c = Node::new(0x4, "C");
-	///
-	/// b.connect(&a, 0.42);
-	/// c.connect(&a, 1.7);
-	///
-	/// assert!(a.in_degree() == 2);
-	pub fn in_degree(&self) -> usize {
-		self.inner.2.borrow().len_inbound()
-	}
+    /// Returns the in-degree of the node. The out degree is the number of
+    /// inbound edges.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let a = Node::new(0x1, "A");
+    /// let b = Node::new(0x2, "B");
+    /// let c = Node::new(0x4, "C");
+    ///
+    /// b.connect(&a, 0.42);
+    /// c.connect(&a, 1.7);
+    ///
+    /// assert!(a.in_degree() == 2);
+    pub fn in_degree(&self) -> usize {
+        self.inner.2.borrow().len_inbound()
+    }
 
     /// Connects this node to another node. The connection is created in both
     /// directions. The connection is created with the given edge value and
@@ -198,10 +230,13 @@ where
     ///	assert!(n1.is_connected(n2.key()));
     /// ```
     pub fn connect(&self, other: &Self, value: E) {
-        self.inner.2
+        self.inner
+            .2
             .borrow_mut()
             .push_outbound((other.clone(), value.clone()));
-        other.inner.2
+        other
+            .inner
+            .2
             .borrow_mut()
             .push_inbound((self.clone(), value));
     }
@@ -241,7 +276,7 @@ where
 
     /// Disconnect two nodes from each other. The connection is removed in both
     /// directions. Returns Ok(EdgeValue) if the connection was removed,
-	/// Err(()) if the connection doesn't exist.
+    /// Err(()) if the connection doesn't exist.
     ///
     /// # Example
     ///
@@ -263,13 +298,9 @@ where
     /// ```
     pub fn disconnect(&self, other: &K) -> Result<E, ()> {
         match self.find_outbound(other) {
-            Some(other) => match self.inner.2
-				.borrow_mut()
-				.remove_outbound(other.key()) {
+            Some(other) => match self.inner.2.borrow_mut().remove_outbound(other.key()) {
                 Ok(edge) => {
-                    other.inner.2
-						.borrow_mut()
-						.remove_inbound(self.key())?;
+                    other.inner.2.borrow_mut().remove_inbound(self.key())?;
                     Ok(edge)
                 }
                 Err(_) => Err(()),
@@ -306,17 +337,11 @@ where
     ///	assert!(n1.is_orphan());
     /// ```
     pub fn isolate(&self) {
-        for (_, v, _) in self.iter_out() {
-            v.inner.2
-                .borrow_mut()
-                .remove_inbound(self.key())
-                .unwrap();
+        for Edge(_, v, _) in self.iter_out() {
+            v.inner.2.borrow_mut().remove_inbound(self.key()).unwrap();
         }
-        for (v, _, _) in self.iter_in() {
-            v.inner.2
-                .borrow_mut()
-                .remove_outbound(self.key())
-                .unwrap();
+        for Edge(v, _, _) in self.iter_in() {
+            v.inner.2.borrow_mut().remove_outbound(self.key()).unwrap();
         }
         self.inner.2.borrow_mut().clear_outbound();
         self.inner.2.borrow_mut().clear_inbound();
@@ -324,107 +349,108 @@ where
 
     /// Returns true if the node is a root node. Root nodes are nodes that have
     /// no incoming connections.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	///
-	/// n1.connect(&n2, ());
-	///
-	/// assert!(n1.is_root());
-	/// assert!(!n2.is_root());
-	/// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    ///
+    /// n1.connect(&n2, ());
+    ///
+    /// assert!(n1.is_root());
+    /// assert!(!n2.is_root());
+    /// ```
     pub fn is_root(&self) -> bool {
         self.inner.2.borrow().len_inbound() == 0
     }
 
     /// Returns true if the node is a leaf node. Leaf nodes are nodes that have
     /// no outgoing connections.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	///
-	/// n1.connect(&n2, ());
-	///
-	/// assert!(!n1.is_leaf());
-	/// assert!(n2.is_leaf());
-	/// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    ///
+    /// n1.connect(&n2, ());
+    ///
+    /// assert!(!n1.is_leaf());
+    /// assert!(n2.is_leaf());
+    /// ```
     pub fn is_leaf(&self) -> bool {
         self.inner.2.borrow().len_outbound() == 0
     }
 
     /// Returns true if the node is an oprhan. Orphan nodes are nodes that have
     /// no connections.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	///
-	/// n1.connect(&n2, ());
-	///
-	/// assert!(!n1.is_orphan());
-	///
-	/// n1.disconnect(n2.key()).unwrap();
-	///
-	/// assert!(n1.is_orphan());
-	/// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    ///
+    /// n1.connect(&n2, ());
+    ///
+    /// assert!(!n1.is_orphan());
+    ///
+    /// n1.disconnect(n2.key()).unwrap();
+    ///
+    /// assert!(n1.is_orphan());
+    /// ```
     pub fn is_orphan(&self) -> bool {
         self.is_root() && self.is_leaf()
     }
 
     /// Returns true if the node is connected to another node with a given key.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	///
-	/// n1.connect(&n2, ());
-	///
-	/// assert!(n1.is_connected(n2.key()));
-	/// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    ///
+    /// n1.connect(&n2, ());
+    ///
+    /// assert!(n1.is_connected(n2.key()));
+    /// ```
     pub fn is_connected(&self, other: &K) -> bool {
         self.find_outbound(other).is_some()
     }
 
     /// Get a pointer to an adjacent node with a given key. Returns None if no
     /// node with the given key is found from the node's adjacency list.
-	/// Outbound edges are searches, this is the default direction.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n1.connect(&n3, ());
-	///
-	/// assert!(n1.find_outbound(n2.key()).is_some());
-	/// assert!(n1.find_outbound(n3.key()).is_some());
-	/// assert!(n1.find_outbound(&4).is_none());
-	/// ```
+    /// Outbound edges are searches, this is the default direction.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n1.connect(&n3, ());
+    ///
+    /// assert!(n1.find_outbound(n2.key()).is_some());
+    /// assert!(n1.find_outbound(n3.key()).is_some());
+    /// assert!(n1.find_outbound(&4).is_none());
+    /// ```
     pub fn find_outbound(&self, other: &K) -> Option<Node<K, N, E>> {
-        let edge = self.inner.2.borrow().find_outbound(other);
+        let edge = self.inner.2.borrow();
+		let edge = edge.find_outbound(other);
         if let Some(edge) = edge {
             Some(edge.0.clone())
         } else {
@@ -432,28 +458,29 @@ where
         }
     }
 
-	/// Get a pointer to an adjacent node with a given key. Returns None if no
-	/// node with the given key is found from the node's adjacency list.
-	/// Inbound edges are searched ie. the transposed graph.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n1.connect(&n3, ());
-	///
-	/// assert!(n2.find_inbound(n1.key()).is_some());
-	/// assert!(n3.find_inbound(n1.key()).is_some());
-	/// assert!(n1.find_inbound(&4).is_none());
-	/// ```
+    /// Get a pointer to an adjacent node with a given key. Returns None if no
+    /// node with the given key is found from the node's adjacency list.
+    /// Inbound edges are searched ie. the transposed graph.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n1.connect(&n3, ());
+    ///
+    /// assert!(n2.find_inbound(n1.key()).is_some());
+    /// assert!(n3.find_inbound(n1.key()).is_some());
+    /// assert!(n1.find_inbound(&4).is_none());
+    /// ```
     pub fn find_inbound(&self, other: &K) -> Option<Node<K, N, E>> {
-        let edge = self.inner.2.borrow().find_inbound(other);
+        let edge = self.inner.2.borrow();
+		let edge = edge.find_inbound(other);
         if let Some(edge) = edge {
             Some(edge.0.clone())
         } else {
@@ -461,29 +488,29 @@ where
         }
     }
 
-	/// Returns an iterator-like object that can be used to map, filter and
+    /// Returns an iterator-like object that can be used to map, filter and
     /// collect reachable nodes or edges in different orderings such as
     /// postorder or preorder.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n2.connect(&n3, ());
-	/// n3.connect(&n1, ());
-	///
-	/// let order = n1.preorder().search_nodes();
-	///
-	/// assert!(order[0] == n1);
-	/// assert!(order[1] == n2);
-	/// assert!(order[2] == n3);
-	/// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n2.connect(&n3, ());
+    /// n3.connect(&n1, ());
+    ///
+    /// let order = n1.preorder().search_nodes();
+    ///
+    /// assert!(order[0] == n1);
+    /// assert!(order[1] == n2);
+    /// assert!(order[2] == n3);
+    /// ```
     pub fn preorder(&self) -> Order<K, N, E> {
         Order::preorder(self)
     }
@@ -491,91 +518,91 @@ where
     /// Returns an iterator-like object that can be used to map, filter and
     /// collect reachable nodes or edges in different orderings such as
     /// postorder or preorder.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n2.connect(&n3, ());
-	/// n3.connect(&n1, ());
-	///
-	/// let order = n1.postorder().search_nodes();
-	///
-	/// assert!(order[2] == n1);
-	/// assert!(order[1] == n2);
-	/// assert!(order[0] == n3);
-	/// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n2.connect(&n3, ());
+    /// n3.connect(&n1, ());
+    ///
+    /// let order = n1.postorder().search_nodes();
+    ///
+    /// assert!(order[2] == n1);
+    /// assert!(order[1] == n2);
+    /// assert!(order[0] == n3);
+    /// ```
     pub fn postorder(&self) -> Order<K, N, E> {
         Order::postroder(self)
     }
 
     /// Returns an iterator-like object that can be used to map, filter,
     /// search and collect nodes or edges resulting from a depth-first search.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n2.connect(&n3, ());
-	/// n3.connect(&n1, ());
-	///
-	/// let path = n1
-	/// 	.dfs()
-	/// 	.target(&3)
-	/// 	.search_path()
-	/// 	.unwrap();
-	///
-	/// let mut iter = path.iter_nodes();
-	///
-	/// assert!(iter.next().unwrap() == n1);
-	/// assert!(iter.next().unwrap() == n2);
-	/// assert!(iter.next().unwrap() == n3);
-	/// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n2.connect(&n3, ());
+    /// n3.connect(&n1, ());
+    ///
+    /// let path = n1
+    /// 	.dfs()
+    /// 	.target(&3)
+    /// 	.search_path()
+    /// 	.unwrap();
+    ///
+    /// let mut iter = path.iter_nodes();
+    ///
+    /// assert!(iter.next().unwrap() == n1);
+    /// assert!(iter.next().unwrap() == n2);
+    /// assert!(iter.next().unwrap() == n3);
+    /// ```
     pub fn dfs(&self) -> DFS<K, N, E> {
         DFS::new(self)
     }
 
     /// Returns an iterator-like object that can be used to map, filter,
     /// search and collect nodes or edges resulting from a breadth-first
-	/// search.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n2.connect(&n3, ());
-	/// n3.connect(&n1, ());
-	///
-	/// let path = n1
-	/// 	.bfs()
-	/// 	.target(&3)
-	/// 	.search_path()
-	/// 	.unwrap();
-	///
-	/// let mut iter = path.iter_nodes();
-	///
-	/// assert!(iter.next().unwrap() == n1);
-	/// assert!(iter.next().unwrap() == n2);
-	/// assert!(iter.next().unwrap() == n3);
-	/// ```
+    /// search.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n2.connect(&n3, ());
+    /// n3.connect(&n1, ());
+    ///
+    /// let path = n1
+    /// 	.bfs()
+    /// 	.target(&3)
+    /// 	.search_path()
+    /// 	.unwrap();
+    ///
+    /// let mut iter = path.iter_nodes();
+    ///
+    /// assert!(iter.next().unwrap() == n1);
+    /// assert!(iter.next().unwrap() == n2);
+    /// assert!(iter.next().unwrap() == n3);
+    /// ```
     pub fn bfs(&self) -> BFS<K, N, E> {
         BFS::new(self)
     }
@@ -583,31 +610,31 @@ where
     /// Returns an iterator-like object that can be used to map, filter,
     /// search and collect nodes or edges resulting from a
     /// priority-first search.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new('A', 0);
-	/// let n2 = Node::new('B', 42);
-	/// let n3 = Node::new('C', 7);
-	/// let n4 = Node::new('D', 23);
-	///
-	/// n1.connect(&n2, ());
-	/// n1.connect(&n3, ());
-	/// n2.connect(&n4, ());
-	/// n3.connect(&n4, ());
-	///
-	/// let path = n1
-	/// 	.pfs()
-	/// 	.target(&'D')
-	/// 	.search_path()
-	/// 	.unwrap();
-	///
-	/// assert!(path[0] == (n1, n3.clone(), ()));
-	/// assert!(path[1] == (n3, n4, ()));
-	///```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new('A', 0);
+    /// let n2 = Node::new('B', 42);
+    /// let n3 = Node::new('C', 7);
+    /// let n4 = Node::new('D', 23);
+    ///
+    /// n1.connect(&n2, ());
+    /// n1.connect(&n3, ());
+    /// n2.connect(&n4, ());
+    /// n3.connect(&n4, ());
+    ///
+    /// let path = n1
+    /// 	.pfs()
+    /// 	.target(&'D')
+    /// 	.search_path()
+    /// 	.unwrap();
+    ///
+    /// assert!(path[0] == Edge(n1, n3.clone(), ()));
+    /// assert!(path[1] == Edge(n3, n4, ()));
+    ///```
     pub fn pfs(&self) -> PFS<K, N, E>
     where
         N: Ord,
@@ -615,24 +642,24 @@ where
         PFS::new(self)
     }
 
-    /// Returns an iterator over the node's outbound edges.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n1.connect(&n3, ());
-	///
-	/// let mut iter = n1.iter_out();
-	/// assert!(iter.next().unwrap() == (n1.clone(), n2.clone(), ()));
-	/// assert!(iter.next().unwrap() == (n1, n3, ()));
-	/// ```
+	/// Returns an iterator over the node's outbound edges.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n1.connect(&n3, ());
+    ///
+    /// let mut iter = n1.iter_out();
+    /// assert!(iter.next().unwrap() == Edge(n1.clone(), n2.clone(), ()));
+    /// assert!(iter.next().unwrap() == Edge(n1, n3, ()));
+    /// ```
     pub fn iter_out(&self) -> IterOut<K, N, E> {
         IterOut {
             node: self,
@@ -640,25 +667,25 @@ where
         }
     }
 
-    /// Returns an iterator over the node's inbound edges.
-	///
-	/// # Example
-	///
-	/// ```
-	/// use gdsl::digraph::*;
-	///
-	/// let n1 = Node::new(1, ());
-	/// let n2 = Node::new(2, ());
-	/// let n3 = Node::new(3, ());
-	///
-	/// n1.connect(&n2, ());
-	/// n1.connect(&n3, ());
-	///
-	/// let mut iter = n2.iter_in();
-	///
-	/// assert!(iter.next().unwrap() == (n1.clone(), n2.clone(), ()));
-	/// assert!(iter.next().is_none());
-	/// ```
+	/// Returns an iterator over the node's inbound edges.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gdsl::digraph::*;
+    ///
+    /// let n1 = Node::new(1, ());
+    /// let n2 = Node::new(2, ());
+    /// let n3 = Node::new(3, ());
+    ///
+    /// n1.connect(&n2, ());
+    /// n1.connect(&n3, ());
+    ///
+    /// let mut iter = n2.iter_in();
+    ///
+    /// assert!(iter.next().unwrap() == Edge(n1.clone(), n2.clone(), ()));
+    /// assert!(iter.next().is_none());
+    /// ```
     pub fn iter_in(&self) -> IterIn<K, N, E> {
         IterIn {
             node: self,
@@ -666,13 +693,13 @@ where
         }
     }
 
-	/// Return's the node's size in bytes.
+    /// Return's the node's size in bytes.
     pub fn sizeof(&self) -> usize {
-		std::mem::size_of::<Node<K, N, E>>()
-			+ std::mem::size_of::<K>()
-			+ std::mem::size_of::<N>()
-			+ self.inner.2.borrow().sizeof()
-			+ std::mem::size_of::<Self>()
+        std::mem::size_of::<Node<K, N, E>>()
+            + std::mem::size_of::<K>()
+            + std::mem::size_of::<N>()
+            + self.inner.2.borrow().sizeof()
+            + std::mem::size_of::<Self>()
     }
 }
 
@@ -704,7 +731,8 @@ where
     K: Clone + Hash + Display + PartialEq + Eq,
     N: Clone,
     E: Clone,
-{}
+{
+}
 
 impl<K, N, E> PartialOrd for Node<K, N, E>
 where
@@ -729,6 +757,36 @@ where
 }
 
 /// An iterator over the node's outbound edges.
+// pub struct RefIterOut<'a, K, N, E>
+// where
+//     K: Clone + Hash + Display + PartialEq + Eq,
+//     N: Clone,
+//     E: Clone,
+// {
+//     node: &'a Node<K, N, E>,
+//     position: usize,
+// }
+
+// impl<'a, K, N, E> Iterator for RefIterOut<'a, K, N, E>
+// where
+//     K: Clone + Hash + Display + PartialEq + Eq,
+//     N: Clone,
+//     E: Clone,
+// {
+//     type Item = EdgeRef<'a, K, N, E>;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         match self.node.inner.2.borrow().get_outbound(self.position) {
+//             Some(current) => {
+//                 self.position += 1;
+//                 Some(EdgeRef(self.node, current.0, current.1))
+//             }
+//             None => None,
+//         }
+//     }
+// }
+
+
 pub struct IterOut<'a, K, N, E>
 where
     K: Clone + Hash + Display + PartialEq + Eq,
@@ -745,23 +803,52 @@ where
     N: Clone,
     E: Clone,
 {
-    type Item = (Node<K, N, E>, Node<K, N, E>, E);
+    type Item = Edge<K, N, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.node.inner.2.borrow().get_outbound(self.position) {
             Some(current) => {
                 self.position += 1;
-                Some((self.node.clone(), current.0, current.1))
+                Some(Edge(self.node.clone(), current.0.clone(), current.1.clone()))
             }
             None => None,
         }
     }
 }
 
-/// An iterator over the node's inbound edges.
+// /// An iterator over the node's inbound edges.
+// pub struct RefIterIn<'a, K, N, E>
+// where
+//     K: Clone + Hash + Display + PartialEq + Eq + Display,
+//     N: Clone,
+//     E: Clone,
+// {
+//     node: &'a Node<K, N, E>,
+//     position: usize,
+// }
+
+// impl<'a, K, N, E> Iterator for RefIterIn<'a, K, N, E>
+// where
+//     K: Clone + Hash + Display + PartialEq + Eq + Display,
+//     N: Clone,
+//     E: Clone,
+// {
+//     type Item = EdgeRef<'a, K, N, E>;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         match self.node.inner.2.borrow().get_inbound(self.position) {
+//             Some(current) => {
+//                 self.position += 1;
+//                 Some(EdgeRef(current.0, self.node, current.1))
+//             }
+//             None => None,
+//         }
+//     }
+// }
+
 pub struct IterIn<'a, K, N, E>
 where
-    K: Clone + Hash + Display + PartialEq + Eq,
+    K: Clone + Hash + Display + PartialEq + Eq + Display,
     N: Clone,
     E: Clone,
 {
@@ -771,17 +858,17 @@ where
 
 impl<'a, K, N, E> Iterator for IterIn<'a, K, N, E>
 where
-    K: Clone + Hash + Display + PartialEq + Eq,
+    K: Clone + Hash + Display + PartialEq + Eq + Display,
     N: Clone,
     E: Clone,
 {
-    type Item = (Node<K, N, E>, Node<K, N, E>, E);
+    type Item = Edge<K, N, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.node.inner.2.borrow().get_inbound(self.position) {
             Some(current) => {
                 self.position += 1;
-                Some((current.0, self.node.clone(), current.1))
+                Some(Edge(current.0.clone(), self.node.clone(), current.1.clone()))
             }
             None => None,
         }
@@ -794,7 +881,7 @@ where
     N: Clone,
     E: Clone,
 {
-    type Item = (Node<K, N, E>, Node<K, N, E>, E);
+    type Item = Edge<K, N, E>;
     type IntoIter = IterOut<'a, K, N, E>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/src/digraph/node/order.rs
+++ b/src/digraph/node/order.rs
@@ -74,12 +74,12 @@ where
 					Ordering::Pre => {
 						self.preorder_forward(&mut edges, &mut visited, &mut queue);
 						nodes.push(self.root.clone());
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 					},
 					Ordering::Post => {
 						self.postorder_forward(&mut edges, &mut visited, &mut queue);
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 						nodes.push(self.root.clone());
 					},
@@ -90,12 +90,12 @@ where
 					Ordering::Pre => {
 						self.preorder_backward(&mut edges, &mut visited, &mut queue);
 						nodes.push(self.root.clone());
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 					},
 					Ordering::Post => {
 						self.postorder_backward(&mut edges, &mut visited, &mut queue);
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 						nodes.push(self.root.clone());
 					},
@@ -145,12 +145,13 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
-				if visited.contains(v.key()) == false {
-					if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
+					if visited.contains(v.key()) == false {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						self.preorder_forward(
 							result,
 							visited,
@@ -169,12 +170,14 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
-				if visited.contains(v.key()) == false {
-					if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_in() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
+					if visited.contains(v.key()) == false {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						self.preorder_forward(
 							result,
 							visited,
@@ -193,16 +196,17 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
-				if visited.contains(v.key()) == false {
-					if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
+					if visited.contains(v.key()) == false {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
 						self.postorder_forward(
 							result,
 							visited,
 							queue);
-						result.push((u, v.clone(), e));
+						result.push(edge);
 					}
 				}
 			}
@@ -217,16 +221,18 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
-				if visited.contains(v.key()) == false {
-					if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_in() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
+					if visited.contains(v.key()) == false {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
 						self.postorder_forward(
 							result,
 							visited,
 							queue);
-						result.push((u, v.clone(), e));
+						result.push(edge);
 					}
 				}
 			}

--- a/src/digraph/node/path.rs
+++ b/src/digraph/node/path.rs
@@ -16,10 +16,11 @@ where
 	let w = edge_tree.last().unwrap();
 	path.push(w.clone());
 	let mut i = 0;
-	for (u, v, e) in edge_tree.iter().rev() {
-		let (s, _, _) = &path[i];
+	for edge in edge_tree.iter().rev() {
+		let Edge(_, v, _) = edge;
+		let Edge(s, _, _) = &path[i];
 		if s == v {
-			path.push((u.clone(), v.clone(), e.clone()));
+			path.push(edge.clone());
 			i += 1;
 		}
 	}

--- a/src/digraph/node/path.rs
+++ b/src/digraph/node/path.rs
@@ -122,13 +122,13 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		match self.path.edges.get(self.position) {
 			Some(edge) => {
 				self.position += 1;
-				Some((edge.0.clone(), edge.1.clone(), edge.2.clone()))
+				Some(Edge(edge.0.clone(), edge.1.clone(), edge.2.clone()))
 			}
 			None => None,
 		}

--- a/src/digraph/node/pfs.rs
+++ b/src/digraph/node/pfs.rs
@@ -86,11 +86,12 @@ where
 	) -> bool {
 		while let Some(node) = queue.pop() {
 			let node = node.0;
-			for (u, v, e) in node.iter_out() {
-				if !visited.contains(v.key()) {
-					if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
+					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -110,11 +111,13 @@ where
 	) -> bool {
 		while let Some(node) = queue.pop() {
 			let node = node.0;
-			for (v, u, e) in node.iter_in() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -133,11 +136,12 @@ where
 		queue: &mut BinaryHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_out() {
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -156,11 +160,13 @@ where
 		queue: &mut BinaryHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
-				if self.method.exec(&u, &v, &e) {
+			for edge in node.iter_in() {
+				let edge = edge.reverse();
+				let v = edge.1.clone();
+				if self.method.exec(&edge) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(edge);
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //!
 //! ```
 //! use gdsl::*;
+//! use gdsl::digraph::*;
 //! use std::cell::Cell;
 //!
 //! // We create a directed graph using the `digraph![]` macro. In the macro
@@ -80,7 +81,7 @@
 //! //
 //! // The search-object evaluates lazily. This means that the search is only
 //! // executed when calling either `search()` or `search_path()`.
-//! g['A'].pfs().map(&|u, v, e| {
+//! g['A'].pfs().map(&|Edge(u, v, e)| {
 //!
 //! 	// Since we are using a `Cell` to store the distance we use `get()` to
 //! 	// read the distance values.

--- a/src/sync_digraph/graph_serde.rs
+++ b/src/sync_digraph/graph_serde.rs
@@ -17,7 +17,7 @@ where
 	for (_, n) in g.iter() {
 		nodes.push((n.key().clone(), n.value().clone()));
 
-		for (u, v, e) in n.iter_out() {
+		for Edge(u, v, e) in n.iter_out() {
 			edges.push((u.key().clone(), v.key().clone(), e));
 		}
 	}

--- a/src/sync_digraph/mod.rs
+++ b/src/sync_digraph/mod.rs
@@ -429,7 +429,7 @@ where
         s.push_str("digraph {\n");
         for (u_key, node) in self.iter() {
             s.push_str(&format!("    {}", u_key.clone()));
-            for (_, v, _) in node {
+            for Edge(_, v, _) in node {
                 s.push_str(&format!("\n    {} -> {}", u_key, v.key()));
             }
             s.push_str("\n");
@@ -467,7 +467,7 @@ where
             s.push_str("\n");
         }
         for (_, node) in self.iter() {
-            for (u, v, edge) in node {
+            for Edge(u, v, edge) in node {
                 s.push_str(&format!("\t{} -> {}", u.key(), v.key()));
                 if let Some(eattrs) = eattr(&u, &v, &edge) {
                     s.push_str(&format!(" {}", Self::fmt_attr(eattrs)));

--- a/src/sync_digraph/node/bfs.rs
+++ b/src/sync_digraph/node/bfs.rs
@@ -124,11 +124,11 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -147,11 +147,11 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_front() {
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -169,7 +169,7 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
@@ -190,7 +190,7 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		while let Some(node) = queue.pop_front() {
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());

--- a/src/sync_digraph/node/dfs.rs
+++ b/src/sync_digraph/node/dfs.rs
@@ -123,10 +123,10 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -148,10 +148,10 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -172,7 +172,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
 						if self.target.is_some() && self.target.unwrap() == v.key() {
@@ -196,7 +196,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
 						if self.target.is_some() && self.target.unwrap() == v.key() {

--- a/src/sync_digraph/node/mod.rs
+++ b/src/sync_digraph/node/mod.rs
@@ -16,7 +16,7 @@
 //!   and is used to store data associated with the edge.
 //!
 //! ```
-//! use gdsl::digraph::*;
+//! use gdsl::sync_digraph::*;
 //!
 //! type N<'a> = Node<usize, &'a str, f64>;
 //!
@@ -58,7 +58,7 @@ pub type Edge<K, N, E> = (Node<K, N, E>, Node<K, N, E>, E);
 /// # Example
 ///
 /// ```
-/// use gdsl::digraph::*;
+/// use gdsl::sync_digraph::*;
 ///
 /// let a = Node::new(0x1, "A");
 /// let b = Node::new(0x2, "B");
@@ -99,7 +99,7 @@ where
     /// # Example
     ///
     /// ```
-    ///	use gdsl::digraph::*;
+    ///	use gdsl::sync_digraph::*;
     ///
     ///	let n1 = Node::<i32, char, ()>::new(1, 'A');
     ///
@@ -117,7 +117,7 @@ where
     /// # Example
     ///
     /// ```
-    ///	use gdsl::digraph::*;
+    ///	use gdsl::sync_digraph::*;
     ///
     ///	let n1 = Node::<i32, (), ()>::new(1, ());
     ///
@@ -132,7 +132,7 @@ where
     /// # Example
     ///
     /// ```
-    ///	use gdsl::digraph::*;
+    ///	use gdsl::sync_digraph::*;
     ///
     ///	let n1 = Node::<i32, char, ()>::new(1, 'A');
     ///
@@ -148,7 +148,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let a = Node::new(0x1, "A");
 	/// let b = Node::new(0x2, "B");
@@ -169,7 +169,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let a = Node::new(0x1, "A");
 	/// let b = Node::new(0x2, "B");
@@ -194,7 +194,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use gdsl::digraph::*;
+    /// use gdsl::sync_digraph::*;
     ///
     ///	let n1 = Node::new(1, ());
     ///	let n2 = Node::new(2, ());
@@ -223,7 +223,7 @@ where
     /// # Example
     ///
     /// ```
-    ///	use gdsl::digraph::*;
+    ///	use gdsl::sync_digraph::*;
     ///
     ///	let n1 = Node::new(1, ());
     ///	let n2 = Node::new(2, ());
@@ -254,7 +254,7 @@ where
     /// # Example
     ///
     /// ```
-    ///	use gdsl::digraph::*;
+    ///	use gdsl::sync_digraph::*;
     ///
     ///	let n1 = Node::new(1, ());
     ///	let n2 = Node::new(2, ());
@@ -291,7 +291,7 @@ where
     /// # Example
     ///
     /// ```
-    ///	use gdsl::digraph::*;
+    ///	use gdsl::sync_digraph::*;
     ///
     ///	let n1 = Node::new(1, ());
     ///	let n2 = Node::new(2, ());
@@ -338,7 +338,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -358,7 +358,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -378,7 +378,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -400,7 +400,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -420,7 +420,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -449,7 +449,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -478,7 +478,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -505,7 +505,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -531,7 +531,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -564,7 +564,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -597,7 +597,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new('A', 0);
 	/// let n2 = Node::new('B', 42);
@@ -630,7 +630,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());
@@ -655,7 +655,7 @@ where
 	/// # Example
 	///
 	/// ```
-	/// use gdsl::digraph::*;
+	/// use gdsl::sync_digraph::*;
 	///
 	/// let n1 = Node::new(1, ());
 	/// let n2 = Node::new(2, ());

--- a/src/sync_digraph/node/mod.rs
+++ b/src/sync_digraph/node/mod.rs
@@ -48,11 +48,14 @@ use self::{bfs::*, dfs::*, order::*, pfs::*, adjacent::*};
 /// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
 #[derive(Clone, PartialEq)]
-pub struct Edge<K: Clone + Hash + PartialEq + Eq + Display, N: Clone, E: Clone>(
+pub struct Edge<K, N, E>(
     pub Node<K, N, E>,
     pub Node<K, N, E>,
     pub E,
-);
+) where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone;
 
 /// A `Node<K, N, E>` is a key value pair smart-pointer, which includes inbound
 /// and outbound connections to other nodes. Nodes can be created individually

--- a/src/sync_digraph/node/order.rs
+++ b/src/sync_digraph/node/order.rs
@@ -74,12 +74,12 @@ where
 					Ordering::Pre => {
 						self.preorder_forward(&mut edges, &mut visited, &mut queue);
 						nodes.push(self.root.clone());
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 					},
 					Ordering::Post => {
 						self.postorder_forward(&mut edges, &mut visited, &mut queue);
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 						nodes.push(self.root.clone());
 					},
@@ -90,12 +90,12 @@ where
 					Ordering::Pre => {
 						self.preorder_backward(&mut edges, &mut visited, &mut queue);
 						nodes.push(self.root.clone());
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 					},
 					Ordering::Post => {
 						self.postorder_backward(&mut edges, &mut visited, &mut queue);
-						let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+						let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 						nodes.append(&mut coll);
 						nodes.push(self.root.clone());
 					},
@@ -145,12 +145,12 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						self.preorder_forward(
 							result,
 							visited,
@@ -169,12 +169,12 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						self.preorder_forward(
 							result,
 							visited,
@@ -193,7 +193,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
@@ -202,7 +202,7 @@ where
 							result,
 							visited,
 							queue);
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 					}
 				}
 			}
@@ -217,7 +217,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
@@ -226,7 +226,7 @@ where
 							result,
 							visited,
 							queue);
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 					}
 				}
 			}

--- a/src/sync_digraph/node/path.rs
+++ b/src/sync_digraph/node/path.rs
@@ -16,10 +16,10 @@ where
 	let w = edge_tree.last().unwrap();
 	path.push(w.clone());
 	let mut i = 0;
-	for (u, v, e) in edge_tree.iter().rev() {
-		let (s, _, _) = &path[i];
+	for Edge(u, v, e) in edge_tree.iter().rev() {
+		let Edge(s, _, _) = &path[i];
 		if s == v {
-			path.push((u.clone(), v.clone(), e.clone()));
+			path.push(Edge(u.clone(), v.clone(), e.clone()));
 			i += 1;
 		}
 	}

--- a/src/sync_digraph/node/path.rs
+++ b/src/sync_digraph/node/path.rs
@@ -16,10 +16,11 @@ where
 	let w = edge_tree.last().unwrap();
 	path.push(w.clone());
 	let mut i = 0;
-	for Edge(u, v, e) in edge_tree.iter().rev() {
+	for edge in edge_tree.iter().rev() {
+		let Edge(_, v, _) = edge;
 		let Edge(s, _, _) = &path[i];
 		if s == v {
-			path.push(Edge(u.clone(), v.clone(), e.clone()));
+			path.push(edge.clone());
 			i += 1;
 		}
 	}
@@ -121,13 +122,13 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		match self.path.edges.get(self.position) {
 			Some(edge) => {
 				self.position += 1;
-				Some((edge.0.clone(), edge.1.clone(), edge.2.clone()))
+				Some(Edge(edge.0.clone(), edge.1.clone(), edge.2.clone()))
 			}
 			None => None,
 		}

--- a/src/sync_digraph/node/pfs.rs
+++ b/src/sync_digraph/node/pfs.rs
@@ -86,11 +86,11 @@ where
 	) -> bool {
 		while let Some(node) = queue.pop() {
 			let node = node.0;
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if !visited.contains(v.key()) {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -110,11 +110,11 @@ where
 	) -> bool {
 		while let Some(node) = queue.pop() {
 			let node = node.0;
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -133,11 +133,11 @@ where
 		queue: &mut BinaryHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter_out() {
+			for Edge(u, v, e) in node.iter_out() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -156,11 +156,11 @@ where
 		queue: &mut BinaryHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop() {
-			for (v, u, e) in node.iter_in() {
+			for Edge(v, u, e) in node.iter_in() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}

--- a/src/sync_ungraph/graph_serde.rs
+++ b/src/sync_ungraph/graph_serde.rs
@@ -16,7 +16,7 @@ where
 	for (_, n) in g.iter() {
 		nodes.push((n.key().clone(), n.value().clone()));
 
-		for (u, v, e) in n.iter() {
+		for Edge(u, v, e) in n.iter() {
 			edges.push((u.key().clone(), v.key().clone(), e));
 		}
 	}

--- a/src/sync_ungraph/mod.rs
+++ b/src/sync_ungraph/mod.rs
@@ -232,7 +232,7 @@ where
 		s.push_str("digraph {\n");
 		for (u_key, node) in self.iter() {
 			s.push_str(&format!("    {}", u_key.clone()));
-			for (_, v, _) in node {
+			for Edge(_, v, _) in node {
 				s.push_str(&format!("\n    {} -> {}", u_key, v.key()));
 			}
 			s.push_str("\n");

--- a/src/sync_ungraph/node/bfs.rs
+++ b/src/sync_ungraph/node/bfs.rs
@@ -63,11 +63,11 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -85,7 +85,7 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());

--- a/src/sync_ungraph/node/dfs.rs
+++ b/src/sync_ungraph/node/dfs.rs
@@ -64,10 +64,10 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -88,7 +88,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
 						if self.target.is_some() && self.target.unwrap() == v.key() {

--- a/src/sync_ungraph/node/mod.rs
+++ b/src/sync_ungraph/node/mod.rs
@@ -59,11 +59,14 @@ use self::{
 /// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
 #[derive(Clone, PartialEq)]
-pub struct Edge<K: Clone + Hash + PartialEq + Eq + Display, N: Clone, E: Clone>(
+pub struct Edge<K, N, E>(
     pub Node<K, N, E>,
     pub Node<K, N, E>,
     pub E,
-);
+) where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone;
 
 /// A `Node<K, N, E>` is a key value pair smart-pointer, which includes inbound and
 /// outbound connections to other nodes. Nodes can be created individually and they

--- a/src/sync_ungraph/node/mod.rs
+++ b/src/sync_ungraph/node/mod.rs
@@ -56,9 +56,14 @@ use self::{
 
 //==== PUBLIC =================================================================
 
-/// An edge between nodes is a tuple `(u, v, e)` where `u` is the
+/// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
-pub type Edge<K, N, E> = (Node<K, N, E>, Node<K, N, E>, E);
+#[derive(Clone, PartialEq)]
+pub struct Edge<K: Clone + Hash + PartialEq + Eq + Display, N: Clone, E: Clone>(
+    pub Node<K, N, E>,
+    pub Node<K, N, E>,
+    pub E,
+);
 
 /// A `Node<K, N, E>` is a key value pair smart-pointer, which includes inbound and
 /// outbound connections to other nodes. Nodes can be created individually and they
@@ -80,7 +85,7 @@ pub type Edge<K, N, E> = (Node<K, N, E>, Node<K, N, E>, E);
 /// b.connect(&c, 0.09);
 /// c.connect(&b, 12.9);
 ///
-/// let (u, v, e) = a.iter().next().unwrap();
+/// let Edge(u, v, e) = a.iter().next().unwrap();
 ///
 /// assert!(u == a);
 /// assert!(v == b);
@@ -279,7 +284,7 @@ where
 	///	assert!(n1.is_orphan());
 	/// ```
 	pub fn isolate(&self) {
-		for (_, v, _) in self.iter() {
+		for Edge(_, v, _) in self.iter() {
 			if v.inner.edges.remove_inbound(self.key()).is_err() {
 				v.inner.edges.remove_outbound(self.key()).unwrap();
 			}
@@ -428,14 +433,14 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		let adjacent = &self.node.inner.edges;
 		match adjacent.get_outbound(self.position) {
 			Some(current) => {
 				self.position += 1;
-				Some((
+				Some(Edge(
 					self.node.clone(),
 					current.target().clone(),
 					current.value.clone()
@@ -445,7 +450,7 @@ where
 				match adjacent.get_inbound(self.position - adjacent.len_outbound()) {
 					Some(current) => {
 						self.position += 1;
-						Some((
+						Some(Edge(
 							self.node.clone(),
 							current.target().clone(),
 							current.value.clone()
@@ -464,7 +469,7 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 	type IntoIter = NodeIterator<'a, K, N, E>;
 
 	fn into_iter(self) -> Self::IntoIter {

--- a/src/sync_ungraph/node/order.rs
+++ b/src/sync_ungraph/node/order.rs
@@ -77,12 +77,12 @@ where
 			Ordering::Pre => {
 				self.recurse_preorder(&mut edges, &mut visited, &mut queue);
 				nodes.push(self.root.clone());
-				let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+				let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 				nodes.append(&mut coll);
 			},
 			Ordering::Post => {
 				self.recurse_postorder(&mut edges, &mut visited, &mut queue);
-				let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+				let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 				nodes.append(&mut coll);
 				nodes.push(self.root.clone());
 			},
@@ -116,12 +116,12 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						self.recurse_preorder(
 							result,
 							visited,
@@ -140,7 +140,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
@@ -149,7 +149,7 @@ where
 							result,
 							visited,
 							queue);
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 					}
 				}
 			}

--- a/src/sync_ungraph/node/path.rs
+++ b/src/sync_ungraph/node/path.rs
@@ -1,9 +1,5 @@
-use std::{
-    fmt::Display,
-    hash::Hash, ops::Index,
-};
-
-use crate::sync_ungraph::node::*;
+use std::{fmt::Display, hash::Hash, ops::Index};
+use super::*;
 
 pub fn backtrack_edge_tree<K, N, E>(edge_tree: Vec<Edge<K, N, E>>) -> Vec<Edge<K, N, E>>
 where
@@ -20,10 +16,11 @@ where
 	let w = edge_tree.last().unwrap();
 	path.push(w.clone());
 	let mut i = 0;
-	for Edge(u, v, e) in edge_tree.iter().rev() {
+	for edge in edge_tree.iter().rev() {
+		let Edge(_, v, _) = edge;
 		let Edge(s, _, _) = &path[i];
 		if s == v {
-			path.push(Edge(u.clone(), v.clone(), e.clone()));
+			path.push(edge.clone());
 			i += 1;
 		}
 	}
@@ -46,6 +43,13 @@ where
 	N: Clone,
 	E: Clone,
 {
+	pub fn len(&self) -> usize {
+		// Conceptually a path always contains at least one node,
+		// the root node. The path containes edges, so the length
+		// of the path is the number of edges plus one.
+		self.edges.len() + 1
+	}
+
 	pub fn from_edge_tree(edge_tree: Vec<Edge<K, N, E>>) -> Path<K, N, E> {
 		Path { edges: backtrack_edge_tree(edge_tree) }
 	}
@@ -118,13 +122,13 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		match self.path.edges.get(self.position) {
 			Some(edge) => {
 				self.position += 1;
-				Some((edge.0.clone(), edge.1.clone(), edge.2.clone()))
+				Some(Edge(edge.0.clone(), edge.1.clone(), edge.2.clone()))
 			}
 			None => None,
 		}

--- a/src/sync_ungraph/node/path.rs
+++ b/src/sync_ungraph/node/path.rs
@@ -20,10 +20,10 @@ where
 	let w = edge_tree.last().unwrap();
 	path.push(w.clone());
 	let mut i = 0;
-	for (u, v, e) in edge_tree.iter().rev() {
-		let (s, _, _) = &path[i];
+	for Edge(u, v, e) in edge_tree.iter().rev() {
+		let Edge(s, _, _) = &path[i];
 		if s == v {
-			path.push((u.clone(), v.clone(), e.clone()));
+			path.push(Edge(u.clone(), v.clone(), e.clone()));
 			i += 1;
 		}
 	}

--- a/src/sync_ungraph/node/pfs.rs
+++ b/src/sync_ungraph/node/pfs.rs
@@ -82,11 +82,11 @@ where
 		queue: &mut MinMaxHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_min() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -105,11 +105,11 @@ where
 		queue: &mut MinMaxHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_max() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}

--- a/src/ungraph/graph_serde.rs
+++ b/src/ungraph/graph_serde.rs
@@ -16,7 +16,7 @@ where
 	for (_, n) in g.iter() {
 		nodes.push((n.key().clone(), n.value().clone()));
 
-		for (u, v, e) in n.iter() {
+		for Edge(u, v, e) in n.iter() {
 			edges.push((u.key().clone(), v.key().clone(), e));
 		}
 	}

--- a/src/ungraph/mod.rs
+++ b/src/ungraph/mod.rs
@@ -228,7 +228,7 @@ where
 		s.push_str("digraph {\n");
 		for (u_key, node) in self.iter() {
 			s.push_str(&format!("    {}", u_key.clone()));
-			for (_, v, _) in node {
+			for Edge(_, v, _) in node {
 				s.push_str(&format!("\n    {} -> {}", u_key, v.key()));
 			}
 			s.push_str("\n");

--- a/src/ungraph/node/bfs.rs
+++ b/src/ungraph/node/bfs.rs
@@ -63,11 +63,11 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -85,7 +85,7 @@ where
 		queue: &mut VecDeque<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		while let Some(node) = queue.pop_front() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());

--- a/src/ungraph/node/dfs.rs
+++ b/src/ungraph/node/dfs.rs
@@ -64,10 +64,10 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -88,7 +88,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> Option<Node<K, N, E>> {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if visited.contains(v.key()) == false {
 						if self.target.is_some() && self.target.unwrap() == v.key() {

--- a/src/ungraph/node/mod.rs
+++ b/src/ungraph/node/mod.rs
@@ -57,9 +57,14 @@ use self::{
 
 //==== PUBLIC =================================================================
 
-/// An edge between nodes is a tuple `(u, v, e)` where `u` is the
+/// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
-pub type Edge<K, N, E> = (Node<K, N, E>, Node<K, N, E>, E);
+#[derive(Clone, PartialEq)]
+pub struct Edge<K: Clone + Hash + PartialEq + Eq + Display, N: Clone, E: Clone>(
+    pub Node<K, N, E>,
+    pub Node<K, N, E>,
+    pub E,
+);
 
 /// A `Node<K, N, E>` is a key value pair smart-pointer, which includes inbound and
 /// outbound connections to other nodes. Nodes can be created individually and they
@@ -81,7 +86,7 @@ pub type Edge<K, N, E> = (Node<K, N, E>, Node<K, N, E>, E);
 /// b.connect(&c, 0.09);
 /// c.connect(&b, 12.9);
 ///
-/// let (u, v, e) = a.iter().next().unwrap();
+/// let Edge(u, v, e) = a.iter().next().unwrap();
 ///
 /// assert!(u == a);
 /// assert!(v == b);
@@ -280,7 +285,7 @@ where
 	///	assert!(n1.is_orphan());
 	/// ```
 	pub fn isolate(&self) {
-		for (_, v, _) in self.iter() {
+		for Edge(_, v, _) in self.iter() {
 			if v.inner.edges.remove_inbound(self.key()).is_err() {
 				v.inner.edges.remove_outbound(self.key()).unwrap();
 			}
@@ -429,14 +434,14 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		let adjacent = &self.node.inner.edges;
 		match adjacent.get_outbound(self.position) {
 			Some(current) => {
 				self.position += 1;
-				Some((
+				Some(Edge(
 					self.node.clone(),
 					current.target().clone(),
 					current.value.clone()
@@ -446,7 +451,7 @@ where
 				match adjacent.get_inbound(self.position - adjacent.len_outbound()) {
 					Some(current) => {
 						self.position += 1;
-						Some((
+						Some(Edge(
 							self.node.clone(),
 							current.target().clone(),
 							current.value.clone()
@@ -465,7 +470,7 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 	type IntoIter = NodeIterator<'a, K, N, E>;
 
 	fn into_iter(self) -> Self::IntoIter {
@@ -665,5 +670,3 @@ where
 		self.edges.borrow_mut().outbound.clear();
 	}
 }
-
-//==== EOF ====================================================================

--- a/src/ungraph/node/mod.rs
+++ b/src/ungraph/node/mod.rs
@@ -60,11 +60,14 @@ use self::{
 /// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
 #[derive(Clone, PartialEq)]
-pub struct Edge<K: Clone + Hash + PartialEq + Eq + Display, N: Clone, E: Clone>(
+pub struct Edge<K, N, E>(
     pub Node<K, N, E>,
     pub Node<K, N, E>,
     pub E,
-);
+) where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone;
 
 /// A `Node<K, N, E>` is a key value pair smart-pointer, which includes inbound and
 /// outbound connections to other nodes. Nodes can be created individually and they

--- a/src/ungraph/node/order.rs
+++ b/src/ungraph/node/order.rs
@@ -77,12 +77,12 @@ where
 			Ordering::Pre => {
 				self.recurse_preorder(&mut edges, &mut visited, &mut queue);
 				nodes.push(self.root.clone());
-				let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+				let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 				nodes.append(&mut coll);
 			},
 			Ordering::Post => {
 				self.recurse_postorder(&mut edges, &mut visited, &mut queue);
-				let mut coll = edges.iter().map(|(_, v, _)| v.clone()).collect();
+				let mut coll = edges.iter().map(|Edge(_, v, _)| v.clone()).collect();
 				nodes.append(&mut coll);
 				nodes.push(self.root.clone());
 			},
@@ -116,12 +116,12 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						self.recurse_preorder(
 							result,
 							visited,
@@ -140,7 +140,7 @@ where
 		queue: &mut Vec<Node<K, N, E>>,
 	) -> bool {
 		if let Some(node) = queue.pop() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if visited.contains(v.key()) == false {
 					if self.method.exec(&u, &v, &e) {
 						visited.insert(v.key().clone());
@@ -149,7 +149,7 @@ where
 							result,
 							visited,
 							queue);
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 					}
 				}
 			}

--- a/src/ungraph/node/path.rs
+++ b/src/ungraph/node/path.rs
@@ -20,10 +20,10 @@ where
 	let w = edge_tree.last().unwrap();
 	path.push(w.clone());
 	let mut i = 0;
-	for (u, v, e) in edge_tree.iter().rev() {
-		let (s, _, _) = &path[i];
+	for Edge(u, v, e) in edge_tree.iter().rev() {
+		let Edge(s, _, _) = &path[i];
 		if s == v {
-			path.push((u.clone(), v.clone(), e.clone()));
+			path.push(Edge(u.clone(), v.clone(), e.clone()));
 			i += 1;
 		}
 	}

--- a/src/ungraph/node/path.rs
+++ b/src/ungraph/node/path.rs
@@ -1,9 +1,5 @@
-use std::{
-    fmt::Display,
-    hash::Hash, ops::Index,
-};
-
-use crate::ungraph::node::*;
+use std::{fmt::Display, hash::Hash, ops::Index};
+use super::*;
 
 pub fn backtrack_edge_tree<K, N, E>(edge_tree: Vec<Edge<K, N, E>>) -> Vec<Edge<K, N, E>>
 where
@@ -20,10 +16,11 @@ where
 	let w = edge_tree.last().unwrap();
 	path.push(w.clone());
 	let mut i = 0;
-	for Edge(u, v, e) in edge_tree.iter().rev() {
+	for edge in edge_tree.iter().rev() {
+		let Edge(_, v, _) = edge;
 		let Edge(s, _, _) = &path[i];
 		if s == v {
-			path.push(Edge(u.clone(), v.clone(), e.clone()));
+			path.push(edge.clone());
 			i += 1;
 		}
 	}
@@ -46,6 +43,13 @@ where
 	N: Clone,
 	E: Clone,
 {
+	pub fn len(&self) -> usize {
+		// Conceptually a path always contains at least one node,
+		// the root node. The path containes edges, so the length
+		// of the path is the number of edges plus one.
+		self.edges.len() + 1
+	}
+
 	pub fn from_edge_tree(edge_tree: Vec<Edge<K, N, E>>) -> Path<K, N, E> {
 		Path { edges: backtrack_edge_tree(edge_tree) }
 	}
@@ -118,13 +122,13 @@ where
 	N: Clone,
 	E: Clone,
 {
-	type Item = (Node<K, N, E>, Node<K, N, E>, E);
+	type Item = Edge<K, N, E>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		match self.path.edges.get(self.position) {
 			Some(edge) => {
 				self.position += 1;
-				Some((edge.0.clone(), edge.1.clone(), edge.2.clone()))
+				Some(Edge(edge.0.clone(), edge.1.clone(), edge.2.clone()))
 			}
 			None => None,
 		}

--- a/src/ungraph/node/pfs.rs
+++ b/src/ungraph/node/pfs.rs
@@ -82,11 +82,11 @@ where
 		queue: &mut MinMaxHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_min() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}
@@ -105,11 +105,11 @@ where
 		queue: &mut MinMaxHeap<Node<K, N, E>>,
 	) -> bool {
 		while let Some(node) = queue.pop_max() {
-			for (u, v, e) in node.iter() {
+			for Edge(u, v, e) in node.iter() {
 				if self.method.exec(&u, &v, &e) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
-						result.push((u, v.clone(), e));
+						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return true;
 						}

--- a/tests/digraph_tests.rs
+++ b/tests/digraph_tests.rs
@@ -28,7 +28,7 @@ fn ut_digraph_manual_bfs()
 	visited.insert(g[0].key().clone());
 
 	while let Some(node) = queue.pop_front() {
-		for (_, v, _) in &node {
+		for Edge(_, v, _) in &node {
 			if !visited.contains(v.key()) {
 				if v == g[4] {
 					return;
@@ -80,7 +80,7 @@ fn ut_digraph()
 	b.connect(&c, 0.09);
 	c.connect(&b, 12.9);
 
-	let (u, v, e) = a.iter_out().next().unwrap();
+	let Edge(u, v, e) = a.iter_out().next().unwrap();
 
 	assert!(u == a);
 	assert!(v == b);
@@ -364,7 +364,7 @@ fn ut_digraph_deref_node() {
 	assert!(*n1 == 42);
 	assert!(n2.key() == &'B');
 
-	let (u, v, e) = n1.iter_out().next().unwrap();
+	let Edge(u, v, e) = n1.iter_out().next().unwrap();
 
 	assert!(u.key() == &'A');
 	assert!(v == n2);
@@ -397,7 +397,7 @@ fn ut_serde_json() {
 
 	for (a, b) in graph_vec.iter().zip(de_vec.iter()) {
 		assert!(a == b);
-		for ((u, v, e), (u2, v2, e2)) in a.iter_out().zip(b.iter_out()) {
+		for (Edge(u, v, e), Edge(u2, v2, e2)) in a.iter_out().zip(b.iter_out()) {
 			assert!(u == u2);
 			assert!(v == v2);
 			assert!(e == e2);
@@ -431,7 +431,7 @@ fn ut_serde_cbor() {
 
 	for (a, b) in graph_vec.iter().zip(de_vec.iter()) {
 		assert!(a == b);
-		for ((u, v, e), (u2, v2, e2)) in a.iter_out().zip(b.iter_out()) {
+		for (Edge(u, v, e), Edge(u2, v2, e2)) in a.iter_out().zip(b.iter_out()) {
 			assert!(u == u2);
 			assert!(v == v2);
 			assert!(e == e2);
@@ -470,7 +470,7 @@ fn ut_serde_cbor_big() {
 
 	for (a, b) in graph_vec.iter().zip(de_vec.iter()) {
 		assert!(a == b);
-		for ((u, v, e), (u2, v2, e2)) in a.iter_out().zip(b.iter_out()) {
+		for (Edge(u, v, e), Edge(u2, v2, e2)) in a.iter_out().zip(b.iter_out()) {
 			assert!(u == u2);
 			assert!(v == v2);
 			assert!(e == e2);
@@ -574,4 +574,20 @@ fn ut_digraph_scc() {
 	assert!(scc[1].len() == 3);
 	assert!(scc[2].len() == 3);
 	assert!(scc[3].len() == 3);
+}
+
+#[test]
+fn ut_digraph_xx() {
+	use gdsl::digraph::*;
+	let n1 = Node::new(0, ());
+	let n2 = Node::new(1, ());
+	let n3 = Node::new(2, ());
+
+	n1.connect(&n2, ());
+	n2.connect(&n3, ());
+	n3.connect(&n1, ());
+
+	for Edge(u, v, e) in &n1 {
+		println!("{} -> {} ({:?})", u.key(), v.key(), e);
+	}
 }

--- a/tests/ungraph_tests.rs
+++ b/tests/ungraph_tests.rs
@@ -28,7 +28,7 @@ fn ut_ungraph_manual_bfs()
 	visited.insert(g[0].key().clone());
 
 	while let Some(node) = queue.pop_front() {
-		for (_, v, _) in &node {
+		for Edge(_, v, _) in &node {
 			if !visited.contains(v.key()) {
 				if v == g[4] {
 					return;
@@ -80,7 +80,7 @@ fn ut_ungraph()
 	b.connect(&c, 0.09);
 	c.connect(&b, 12.9);
 
-	let (u, v, e) = a.iter().next().unwrap();
+	let Edge(u, v, e) = a.iter().next().unwrap();
 
 	assert!(u == a);
 	assert!(v == b);


### PR DESCRIPTION
Edge is now denoted as a tuple struct

```rust

pub struct Edge<K, N, E>(
    pub Node<K, N, E>,
    pub Node<K, N, E>,
    pub E,
) where
	K: Clone + Hash + PartialEq + Eq + Display,
	N: Clone,
	E: Clone;
```

This gives more flexibility in how to use iterators over edges, the `Path<K, N, E>` type etc. because
now the edge doesn't have to be decomposed in the iterator or closure arguments in case user
wants to store it in a result for example.

Iteratior over nodes edges is now as follows:

```rust

// Edge is a tuple struct so can be decomposed using tuple syntax..
for Edge(u, v, e) in &node {
    println!("{} -> {} : {}", u.key(), v.key(), e);
}

// ..or used more conventionally as one type.
for edge in &node {
    println!("{} -> {} : {}", edge.source().key(), edge.target().key(), edge.value());
}

```