### PR TITLE
22 add minimum spanning tree to examples

### DIFF
--- a/examples/prim.rs
+++ b/examples/prim.rs
@@ -6,31 +6,8 @@ use std::cell::RefCell;
 
 type N = Node<usize, (), u64>;
 type E = Edge<usize, (), u64>;
-type Heap = BinaryHeap<Reverse<ForestEdge>>;
+type Heap = BinaryHeap<Reverse<E>>;
 type Forest = Vec<E>;
-
-#[derive(Clone)]
-struct ForestEdge(E);
-
-impl PartialEq for ForestEdge {
-    fn eq(&self, other: &ForestEdge) -> bool {
-        self.0.2 == other.0.2
-    }
-}
-
-impl Eq for ForestEdge {}
-
-impl PartialOrd for ForestEdge {
-    fn partial_cmp(&self, other: &ForestEdge) -> Option<std::cmp::Ordering> {
-        Some(self.0.2.cmp(&other.0.2))
-    }
-}
-
-impl Ord for ForestEdge {
-    fn cmp(&self, other: &ForestEdge) -> std::cmp::Ordering {
-        self.0.2.cmp(&other.0.2)
-    }
-}
 
 fn prim_minimum_spanning_tree(s: &N) -> Forest {
     let mut forest: Forest = vec![];
@@ -39,19 +16,20 @@ fn prim_minimum_spanning_tree(s: &N) -> Forest {
 
 	added_nodes.insert(*s.key());
 
-	s.bfs().map(&|u, v, e| {
-		heap.borrow_mut().push(Reverse(ForestEdge((u.clone(), v.clone(), *e))));
+	s.bfs().map(&|edge| {
+		heap.borrow_mut().push(Reverse(edge.clone()));
 	}).search();
 
-	let mut tmp: Vec<ForestEdge> = vec![];
+	let mut tmp: Vec<E> = vec![];
 	loop {
 		if let Some(edge) = heap.borrow_mut().pop() {
-			let Reverse(ForestEdge((u, v, e))) = edge;
-			if added_nodes.contains(u.key()) && !added_nodes.contains(v.key()) {
-				forest.push((u.clone(), v.clone(), e));
-				added_nodes.insert(*v.key());
+			let Reverse(edge) = edge;
+			if added_nodes.contains(edge.source().key())
+			&& !added_nodes.contains(edge.target().key()) {
+				forest.push(edge.clone());
+				added_nodes.insert(*edge.target().key());
 			} else {
-				tmp.push(ForestEdge((u.clone(), v.clone(), e)));
+				tmp.push(edge);
 				continue;
 			}
 		} else {

--- a/examples/prim.rs
+++ b/examples/prim.rs
@@ -1,0 +1,94 @@
+use gdsl::ungraph::*;
+use gdsl::*;
+use std::collections::{BinaryHeap, HashSet};
+use std::cmp::Reverse;
+use std::cell::RefCell;
+
+type N = Node<usize, (), u64>;
+type E = Edge<usize, (), u64>;
+type Heap = BinaryHeap<Reverse<ForestEdge>>;
+type Forest = Vec<E>;
+
+#[derive(Clone)]
+struct ForestEdge(E);
+
+impl PartialEq for ForestEdge {
+    fn eq(&self, other: &ForestEdge) -> bool {
+        self.0.2 == other.0.2
+    }
+}
+
+impl Eq for ForestEdge {}
+
+impl PartialOrd for ForestEdge {
+    fn partial_cmp(&self, other: &ForestEdge) -> Option<std::cmp::Ordering> {
+        Some(self.0.2.cmp(&other.0.2))
+    }
+}
+
+impl Ord for ForestEdge {
+    fn cmp(&self, other: &ForestEdge) -> std::cmp::Ordering {
+        self.0.2.cmp(&other.0.2)
+    }
+}
+
+fn prim_minimum_spanning_tree(s: &N) -> Forest {
+    let mut forest: Forest = vec![];
+    let mut added_nodes: HashSet<usize> = HashSet::new();
+	let heap = RefCell::new(Heap::new());
+
+	added_nodes.insert(*s.key());
+
+	s.bfs().map(&|u, v, e| {
+		heap.borrow_mut().push(Reverse(ForestEdge((u.clone(), v.clone(), *e))));
+	}).search();
+
+	let mut tmp: Vec<ForestEdge> = vec![];
+	loop {
+		if let Some(edge) = heap.borrow_mut().pop() {
+			let Reverse(ForestEdge((u, v, e))) = edge;
+			if added_nodes.contains(u.key()) && !added_nodes.contains(v.key()) {
+				forest.push((u.clone(), v.clone(), e));
+				added_nodes.insert(*v.key());
+			} else {
+				tmp.push(ForestEdge((u.clone(), v.clone(), e)));
+				continue;
+			}
+		} else {
+			break;
+		}
+		for tmp_edge in &tmp {
+			heap.borrow_mut().push(Reverse(tmp_edge.clone()));
+		}
+	}
+	forest
+}
+
+fn main() {
+	let g1 = ungraph![
+		(usize) => [u64]
+		(0) => [ (1, 1), (3, 4), (4, 3)]
+		(1) => [ (3, 4), (4, 2)]
+		(2) => [ (4, 4), (5, 5)]
+		(3) => [ (4, 4)]
+		(4) => [ (5, 7)]
+		(5) => []
+	];
+	let forest = prim_minimum_spanning_tree(&g1[0]);
+	let sum = forest.iter().fold(0, |acc, e| acc + e.2);
+	assert!(sum == 16);
+	
+	let g2 = ungraph![
+		(usize) => [u64]
+		(0) => [ (1, 8), (2, 5)]
+		(1) => [ (2, 10), (3, 2), (4, 18)]
+		(2) => [ (3, 3), (5, 16)]
+		(3) => [ (4, 12), (5, 30)]
+		(4) => [ (6, 4)]
+		(5) => [ (6, 26)]
+		(6) => []
+	];
+	let forest = prim_minimum_spanning_tree(&g2[0]);
+	let sum = forest.iter().fold(0, |acc, e| acc + e.2);
+	assert!(sum == 42);
+}

--- a/src/ungraph/node/bfs.rs
+++ b/src/ungraph/node/bfs.rs
@@ -64,7 +64,7 @@ where
 	) -> bool {
 		while let Some(node) = queue.pop_front() {
 			for Edge(u, v, e) in node.iter() {
-				if self.method.exec(&u, &v, &e) {
+				if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
 						result.push(Edge(u, v.clone(), e));
@@ -86,7 +86,7 @@ where
 	) -> Option<Node<K, N, E>> {
 		while let Some(node) = queue.pop_front() {
 			for Edge(u, v, e) in node.iter() {
-				if self.method.exec(&u, &v, &e) {
+				if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
 						if self.target.is_some() && self.target.unwrap() == v.key() {

--- a/src/ungraph/node/dfs.rs
+++ b/src/ungraph/node/dfs.rs
@@ -65,7 +65,7 @@ where
 	) -> bool {
 		if let Some(node) = queue.pop() {
 			for Edge(u, v, e) in node.iter() {
-				if self.method.exec(&u, &v, &e) {
+				if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 					if visited.contains(v.key()) == false {
 						result.push(Edge(u, v.clone(), e));
 						if self.target.is_some() && self.target.unwrap() == v.key() {
@@ -89,7 +89,7 @@ where
 	) -> Option<Node<K, N, E>> {
 		if let Some(node) = queue.pop() {
 			for Edge(u, v, e) in node.iter() {
-				if self.method.exec(&u, &v, &e) {
+				if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 					if visited.contains(v.key()) == false {
 						if self.target.is_some() && self.target.unwrap() == v.key() {
 							return Some(v);

--- a/src/ungraph/node/method.rs
+++ b/src/ungraph/node/method.rs
@@ -1,8 +1,8 @@
 use crate::ungraph::node::*;
 
-pub type FilterMap<'a, K, N, E> = &'a dyn Fn(&Node<K, N, E>, &Node<K, N, E>, &E) -> bool;
-pub type Filter<'a, K, N, E> = &'a dyn Fn(&Node<K, N, E>, &Node<K, N, E>, &E) -> bool;
-pub type Map<'a, K, N, E> = &'a dyn Fn(&Node<K, N, E>, &Node<K, N, E>, &E);
+pub type FilterMap<'a, K, N, E> = &'a dyn Fn(&Edge<K, N,E>) -> bool;
+pub type Filter<'a, K, N, E> = &'a dyn Fn(&Edge<K, N,E>) -> bool;
+pub type Map<'a, K, N, E> = &'a dyn Fn(&Edge<K, N,E>);
 
 #[derive(Clone)]
 pub enum Method<'a, K, N, E>
@@ -23,12 +23,12 @@ where
 	N: Clone,
 	E: Clone,
 {
-	pub fn exec(&self, u: &Node<K, N, E>, v: &Node<K, N, E>, e: &E) -> bool {
+	pub fn exec(&self, e: &Edge<K, N, E>) -> bool {
 		match self {
 			Method::NullMethod => true,
-			Method::Map(f) => {f(u, v, e); true},
-			Method::Filter(f) => f(u, v, e),
-			Method::FilterMap(f) => f(u, v, e),
+			Method::Map(f) => {f(e); true},
+			Method::Filter(f) => f(e),
+			Method::FilterMap(f) => f(e),
 		}
 	}
 }

--- a/src/ungraph/node/mod.rs
+++ b/src/ungraph/node/mod.rs
@@ -59,7 +59,7 @@ use self::{
 
 /// An edge between nodes is a tuple struct `Edge(u, v, e)` where `u` is the
 /// source node, `v` is the target node, and `e` is the edge's value.
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct Edge<K, N, E>(
     pub Node<K, N, E>,
     pub Node<K, N, E>,
@@ -68,6 +68,73 @@ pub struct Edge<K, N, E>(
 	K: Clone + Hash + PartialEq + Eq + Display,
 	N: Clone,
 	E: Clone;
+
+	impl<K, N, E> Edge<K, N, E>
+where
+    K: Clone + Hash + PartialEq + Eq + Display,
+    N: Clone,
+    E: Clone,
+{
+    /// Returns the source node of the edge.
+    pub fn source(&self) -> &Node<K, N, E> {
+        &self.0
+    }
+
+    /// Returns the target node of the edge.
+    pub fn target(&self) -> &Node<K, N, E> {
+        &self.1
+    }
+
+    /// Returns the edge's value.
+    pub fn value(&self) -> &E {
+        &self.2
+    }
+
+    /// Reverse the edge's direction.
+    pub fn reverse(&self) -> Edge<K, N, E> {
+        Edge(self.1.clone(), self.0.clone(), self.2.clone())
+    }
+}
+
+impl<K, N, E> PartialEq for Edge<K, N, E>
+where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone + Ord
+{
+	fn eq(&self, other: &Edge<K, N, E>) -> bool {
+		self.2 == other.2
+	}
+}
+
+impl<K, N, E> Eq for Edge<K, N, E>
+where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone + Ord
+{}
+
+impl<K, N, E> PartialOrd for Edge<K, N, E> 
+where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone + Ord
+{
+	fn partial_cmp(&self, other: &Edge<K, N, E>) -> Option<std::cmp::Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl<K, N, E> Ord for Edge<K, N, E> 
+where
+	K: Clone + Hash + PartialEq + Eq + Display,
+	N: Clone,
+	E: Clone + Ord
+{
+	fn cmp(&self, other: &Edge<K, N, E>) -> std::cmp::Ordering {
+		self.2.cmp(&other.2)
+	}
+}
 
 /// A `Node<K, N, E>` is a key value pair smart-pointer, which includes inbound and
 /// outbound connections to other nodes. Nodes can be created individually and they

--- a/src/ungraph/node/order.rs
+++ b/src/ungraph/node/order.rs
@@ -118,7 +118,7 @@ where
 		if let Some(node) = queue.pop() {
 			for Edge(u, v, e) in node.iter() {
 				if visited.contains(v.key()) == false {
-					if self.method.exec(&u, &v, &e) {
+					if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
 						result.push(Edge(u, v.clone(), e));
@@ -142,7 +142,7 @@ where
 		if let Some(node) = queue.pop() {
 			for Edge(u, v, e) in node.iter() {
 				if visited.contains(v.key()) == false {
-					if self.method.exec(&u, &v, &e) {
+					if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 						visited.insert(v.key().clone());
 						queue.push(v.clone());
 						self.recurse_postorder(

--- a/src/ungraph/node/pfs.rs
+++ b/src/ungraph/node/pfs.rs
@@ -83,7 +83,7 @@ where
 	) -> bool {
 		while let Some(node) = queue.pop_min() {
 			for Edge(u, v, e) in node.iter() {
-				if self.method.exec(&u, &v, &e) {
+				if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
 						result.push(Edge(u, v.clone(), e));
@@ -106,7 +106,7 @@ where
 	) -> bool {
 		while let Some(node) = queue.pop_max() {
 			for Edge(u, v, e) in node.iter() {
-				if self.method.exec(&u, &v, &e) {
+				if self.method.exec(&Edge(u.clone(), v.clone(), e.clone())) {
 					if !visited.contains(v.key()) {
 						visited.insert(v.key().clone());
 						result.push(Edge(u, v.clone(), e));


### PR DESCRIPTION
Added an implementation of Prim's algorithm for finding a minimum spanning tree in an undirected graph.

Short description borrowed from Wikipedia:

> Prim's algorithm (also known as Jarník's algorithm) is a [greedy algorithm](https://en.wikipedia.org/wiki/Greedy_algorithm) that finds a [minimum spanning tree](https://en.wikipedia.org/wiki/Minimum_spanning_tree) for a [weighted](https://en.wikipedia.org/wiki/Weighted_graph) [undirected graph](https://en.wikipedia.org/wiki/Undirected_graph). This means it finds a subset of the [edges](https://en.wikipedia.org/wiki/Edge_(graph_theory)) that forms a [tree](https://en.wikipedia.org/wiki/Tree_(graph_theory)) that includes every [vertex](https://en.wikipedia.org/wiki/Vertex_(graph_theory)), where the total weight of all the [edges](https://en.wikipedia.org/wiki/Graph_theory) in the tree is minimized. The algorithm operates by building this tree one vertex at a time, from an arbitrary starting vertex, at each step adding the cheapest possible connection from the tree to another vertex.

Implementing this required some fixes to the ungraph: fixing the exec method to work with the Edge tuple struct.